### PR TITLE
Add buddy for cluster run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ cython_debug/
 
 # Logs dir
 logs/
+wandb
+runs

--- a/algo/base.py
+++ b/algo/base.py
@@ -11,6 +11,7 @@ from jax import numpy as jnp, jit, vmap
 import numpy as np
 
 from functools import partial
+import experiment_buddy
 
 
 class BaseAlgo(object):
@@ -23,7 +24,8 @@ class BaseAlgo(object):
         self.sys = env.sys
         self._dump_train_config()
         self._init_value_net_and_optimizer()
-        self.summary_writer = logger.get_summary_writer(cfg)
+        self.summary_writer = experiment_buddy.deploy(host=cfg.HOST)
+        # logger.get_summary_writer(cfg)
 
         self.dataset_size = cfg.TRAIN.DATASET_SIZE
         self.batch_size = cfg.TRAIN.BATCH_SIZE
@@ -101,7 +103,7 @@ class BaseAlgo(object):
 
         # report to tb
         if epoch % self.cfg.LOG.LOG_EVERY_N_EPOCHS == 0:
-            self.summary_writer.scalar(
+            self.summary_writer.add_scalar(
                 "train_loss",
                 np.mean(loss_log),
                 epoch,
@@ -111,7 +113,7 @@ class BaseAlgo(object):
         if epoch % self.cfg.LOG.EVAL_EVERY_N_EPOCHS == 0:
             mean_cost = self.eval_policy(self.cfg.LOG.EVAL_ACROSS_N_RUNS)
             print("Env eval cost: {}".format(mean_cost))
-            self.summary_writer.scalar(
+            self.summary_writer.add_scalar(
                 "eval_cost",
                 mean_cost,
                 epoch,

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -61,6 +61,9 @@ _C.LOG.EVAL_ACROSS_N_RUNS = 10
 _C.LOG.SAVE_WEIGHTS_EVERY_N_EPOCHS = 100
 _C.LOG.ANIMATE = False
 
+_C.HOST = "mila"  # use "mila" as host for the cluster
+_C.merge_from_file("./config/Pendulum.yaml")
+
 
 def get_cfg_defaults():
     """Get a yacs CfgNode object with default values for my_project."""

--- a/main.py
+++ b/main.py
@@ -2,32 +2,14 @@ from config.defaults import get_cfg_defaults
 from environment import make_env
 from algo import make_algo
 
-import argparse
+import experiment_buddy
 
 
 def main():
-    parser = argparse.ArgumentParser(description="HJxB")
-    parser.add_argument(
-        "--config-file",
-        default="",
-        metavar="file",
-        help="path to yaml config file",
-        type=str,
-    )
-    parser.add_argument(
-        "--opts",
-        help="Modify config options using the command-line",
-        default=[],
-        nargs=argparse.REMAINDER,
-    )
-
-    args = parser.parse_args()
-
     # build the config
     cfg = get_cfg_defaults()
-    cfg.merge_from_file(args.config_file)
-    cfg.merge_from_list(args.opts)
-    cfg.freeze()
+    experiment_buddy.register(cfg)
+    # cfg.freeze()
 
     env = make_env(cfg)
     algo = make_algo(cfg, env)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tensorboard
 yacs
 gym
 flax==0.3.3
+git+https://github.com/ministry-of-silly-code/experiment_buddy.git@main#egg=experiment_buddy


### PR DESCRIPTION
Follow the readme here:
`https://github.com/ministry-of-silly-code/experiment_buddy` on how to set your ssh config and make sure the cluster can pull from git.

The only caveat is that buddy currently failed on nested objects for your cfg, and eventually you want to be able to edit each and every params, but you get the idea on how it works at least.